### PR TITLE
chore: add flake.nix development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Use nix flake if available
+if nix flake --help &>/dev/null; then
+    use flake .
+fi
+
+dotenv_if_exists .env
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ bot
 
 # Dependencies
 vendor/
+
+# Direnv
+.direnv/
+.env
+.envrc.local

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766870016,
+        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "MissGirlyThing Discord Bot development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems =
+        systems: f:
+        lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+            }
+          )
+        );
+    in
+    {
+      devShells = forAllSystems supportedSystems (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            pkgs.gopls
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
also added minimal `.envrc` to load the flake.nix development environment automatically

Closes #2 